### PR TITLE
Typo in readme, npm package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a very early alpha version, with a couple of [known issues](#known-issue
 ### Installing
 
 ```
-npm i @ivoviz/feedback-js
+npm i @ivoviz/feedback.js
 ```
 
 ### Usage


### PR DESCRIPTION
The npm package name is @ivoviz/feedback.js, not @ivoviz/feedback-js
npm i @ivoviz/feedback.js results in 404.
https://www.npmjs.com/package/@ivoviz/feedback.js